### PR TITLE
Add support for post types to not display the "Analytics" column

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,6 +45,7 @@ Hooks
   - gadwp_gtag_script_path
   - gadwp_maps_api_key
   - gadwp_curl_options
+  - gadwp_post_types_blacklist
 
 * Actions
 

--- a/admin/item-reports.php
+++ b/admin/item-reports.php
@@ -35,10 +35,27 @@ if ( ! class_exists( 'GADWP_Backend_Item_Reports' ) ) {
 			}
 		}
 
+		private function post_type_is_blacklisted()
+		{
+			$post_type = get_post_type();
+
+			if ( ! $post_type ) {
+				return false;
+			}
+
+			// post types to NOT show the "Analytics" column on
+			$blacklist_post_types = [];
+
+			// allow plugins/themes to add post types to the blacklist
+			$blacklist_post_types = apply_filters( 'gadwp_post_types_blacklist', $blacklist_post_types );
+
+			return in_array( $post_type, $blacklist_post_types );
+		}
+
 		public function add_icons( $column, $id ) {
 			global $wp_version;
 
-			if ( 'gadwp_stats' != $column ) {
+			if ( 'gadwp_stats' != $column || $this->post_type_is_blacklisted() ) {
 				return;
 			}
 
@@ -50,6 +67,10 @@ if ( ! class_exists( 'GADWP_Backend_Item_Reports' ) ) {
 		}
 
 		public function add_columns( $columns ) {
+			if ( $this->post_type_is_blacklisted() ) {
+				return $columns;
+			}
+
 			return array_merge( $columns, array( 'gadwp_stats' => __( 'Analytics', 'google-analytics-dashboard-for-wp' ) ) );
 		}
 	}


### PR DESCRIPTION
This is done by adding a filter `gadwp_post_types_blacklist` that expects an array of post types that the "Analytics" column should not be shown on. This is particularly useful with custom post types that will never be directly accessed, and therefore will never have any analytics.

For example:

```php
<?php

add_filter('gadwp_post_types_blacklist', 'quadra_add_post_types_to_gadwp_blacklist');

function quadra_add_post_types_to_gadwp_blacklist($postTypes)
{
	$postTypes[] = 'upsell_customer';
	$postTypes[] = 'upsell_product';
	$postTypes[] = 'upsell_order';

	return $postTypes;
}
```